### PR TITLE
Fixes ValueError: Loading ollama-llm LLM not supported

### DIFF
--- a/libs/community/langchain_community/llms/ollama.py
+++ b/libs/community/langchain_community/llms/ollama.py
@@ -391,7 +391,8 @@ class Ollama(BaseLLM, _OllamaCommon):
     @property
     def _llm_type(self) -> str:
         """Return type of llm."""
-        return "ollama-llm"
+        # return "ollama-llm"
+        return "ollama" #Fixes: ValueError: Loading ollama-llm LLM not supported when loading model from mlflow
 
     def _generate(  # type: ignore[override]
         self,


### PR DESCRIPTION
ValueError: Loading ollama-llm LLM not supported
File <command-4188999679875713>, line 2
      1 # Load the logged model using MLflow's Python function flavor
----> 2 loaded_model = mlflow.langchain.load_model(logged_model.model_uri)
File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.10/site-packages/langchain_community/llms/loading.py:23, in load_llm_from_config(config, **kwargs)
     20 type_to_cls_dict = get_type_to_cls_dict()
     22 if config_type not in type_to_cls_dict:
---> 23     raise ValueError(f"Loading {config_type} LLM not supported")
     25 llm_cls = type_to_cls_dict[config_type]()
     27 load_kwargs = {}